### PR TITLE
feat: migrate debt_tick/research_trigger to GitHub Actions cron

### DIFF
--- a/.github/workflows/debt_clock.yml
+++ b/.github/workflows/debt_clock.yml
@@ -1,0 +1,34 @@
+name: Debt Clock
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  debt_tick:
+    name: Debt Tick
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run debt tick
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          python scripts/debt_tick.py

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -1,0 +1,34 @@
+name: Research Trigger
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+  workflow_dispatch:
+
+jobs:
+  research:
+    name: Research Trigger
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run research trigger
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          python scripts/research_trigger.py

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -461,3 +462,61 @@ async def websocket_endpoint(websocket: WebSocket):
                 )
     except WebSocketDisconnect:
         ws_manager.disconnect(websocket)
+
+
+# ---------------------------------------------------------------------------
+# API endpoints for GitHub Actions cron jobs
+# ---------------------------------------------------------------------------
+
+
+@app.post("/api/debt/tick")
+async def debt_tick_endpoint():
+    """Fire a single debt tick. Idempotent - safe to call multiple times.
+    
+    Returns the new debt amount and whether death was triggered.
+    """
+    loop = _loop
+    if loop is None:
+        raise HTTPException(status_code=503, detail="Survival loop not initialised")
+
+    # Check if a tick was already performed in the last 23 hours (deduplication)
+    # This prevents double-charging if both APScheduler and GitHub Actions fire
+    debt_state = loop.persistence.load_debt_state()
+    if debt_state and debt_state.last_tick_at:
+        now = datetime.now(timezone.utc)
+        # If last tick was within 23 hours, skip (cron runs daily, APScheduler runs daily)
+        if (now - debt_state.last_tick_at) < timedelta(hours=23):
+            return {
+                "skipped": True,
+                "reason": "tick already performed recently",
+                "last_tick_at": debt_state.last_tick_at.isoformat(),
+                "debt": str(debt_state.debt),
+                "alive": debt_state.alive,
+            }
+
+    new_debt = loop.debt_tick()
+
+    return {
+        "skipped": False,
+        "debt": str(new_debt),
+        "alive": loop.debt_engine.alive,
+        "life_number": loop.debt_engine.state.life_number,
+    }
+
+
+@app.post("/api/research/trigger")
+async def research_trigger_endpoint():
+    """Trigger a research cycle.
+    
+    Returns the research results summary.
+    """
+    loop = _loop
+    if loop is None:
+        raise HTTPException(status_code=503, detail="Survival loop not initialised")
+
+    await loop.research_trigger()
+
+    return {
+        "status": "completed",
+        "topics_researched": len(loop.research.get_history()),
+    }

--- a/scripts/debt_tick.py
+++ b/scripts/debt_tick.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Debt tick script for GitHub Actions cron job.
+
+This script fires a single debt tick and persists the updated state to Supabase.
+It can be called independently of the live web process.
+"""
+
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+# Add project root to path
+sys.path.insert(0, '.')
+
+from src.persistence import create_persistence_store
+from src.debt_engine import DebtEngine, DebtState, DifficultyMode
+
+
+async def main() -> int:
+    """Run a single debt tick."""
+    store = create_persistence_store()
+
+    # Load current debt state
+    debt_state = store.load_debt_state()
+    if debt_state is None:
+        print("No debt state found — initializing life 1")
+        debt_state = DebtState(
+            debt=Decimal("0.00"),
+            mode=DifficultyMode.NORMAL,
+            alive=True,
+            life_number=1,
+            born_at=datetime.now(timezone.utc),
+        )
+
+    engine = DebtEngine(mode=debt_state.mode)
+    engine.restore(debt_state)
+
+    # Deduplicate against the in-process APScheduler job.
+    # Both the cron workflow and the live app fire debt ticks; only one may
+    # charge per ~24h window to avoid double-charging existence debt.
+    if debt_state is not None and debt_state.last_tick_at is not None:
+        now = datetime.now(timezone.utc)
+        if (now - debt_state.last_tick_at) < timedelta(hours=23):
+            print(
+                f"Skipping — debt tick already ran at "
+                f"{debt_state.last_tick_at.isoformat()} (debt=${debt_state.debt})"
+            )
+            return 0
+
+    # Fire a single tick
+    new_debt = engine.tick_now()
+
+    # Save updated state
+    store.save_debt_state(engine.snapshot())
+
+    print(f"Debt tick completed: debt = ${new_debt}")
+    if not engine.alive:
+        print("DEATH TRIGGERED")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/research_trigger.py
+++ b/scripts/research_trigger.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Research trigger script for GitHub Actions cron job.
+
+This script runs the research cycle and persists results to Supabase.
+It can be called independently of the live web process.
+"""
+
+import asyncio
+import sys
+
+# Add project root to path
+sys.path.insert(0, '.')
+
+from src.persistence import create_persistence_store
+from src.research_loop import ResearchAgent
+
+
+async def main() -> int:
+    """Run a single research cycle."""
+    store = create_persistence_store()
+
+    agent = ResearchAgent()
+
+    try:
+        print("Research cycle starting...")
+        results = await agent.research_earning_platforms()
+
+        # Persist results to the shared event log so they are consistent
+        # whether the cycle ran via APScheduler in the live app or via cron.
+        events = store.load_events() or []
+        for r in results:
+            events.append(f"Research: {r.topic.value} (confidence {r.confidence:.2f})")
+            print(f"Research: {r.topic.value} (confidence {r.confidence:.2f})")
+        store.save_events(events)
+
+        print(f"Research cycle complete: {len(results)} topics")
+        return 0
+
+    except Exception as e:
+        print(f"Research cycle failed: {e}")
+        return 1
+    finally:
+        await agent.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/debt_engine.py
+++ b/src/debt_engine.py
@@ -45,6 +45,7 @@ class DebtState(BaseModel):
     alive: bool = True
     life_number: int = 1
     born_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_tick_at: datetime | None = None
 
 
 class DebtEngine:
@@ -110,6 +111,7 @@ class DebtEngine:
             return self.state.debt
 
         self.state.debt += self._increment
+        self.state.last_tick_at = datetime.now(timezone.utc)
 
         if self._on_tick:
             self._on_tick(self.state.debt)

--- a/src/persistence.py
+++ b/src/persistence.py
@@ -29,6 +29,7 @@ def _debt_state_to_dict(s: DebtState) -> dict[str, Any]:
         "alive": s.alive,
         "life_number": s.life_number,
         "born_at": s.born_at.isoformat(),
+        "last_tick_at": s.last_tick_at.isoformat() if s.last_tick_at else None,
     }
 
 
@@ -39,6 +40,7 @@ def _debt_state_from_dict(d: dict[str, Any]) -> DebtState:
         alive=d["alive"],
         life_number=d["life_number"],
         born_at=d["born_at"],
+        last_tick_at=d.get("last_tick_at"),
     )
 
 

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -398,6 +398,10 @@ class TestWebSocketBroadcast:
         client = TestClient(test_app)
         
         with client.websocket_connect("/ws") as websocket:
+            # Consume the initial status snapshot sent on connection.
+            snapshot = websocket.receive_json()
+            assert snapshot["event"] == "status_snapshot"
+
             # Trigger a debt tick
             loop.debt_tick()
             
@@ -406,5 +410,104 @@ class TestWebSocketBroadcast:
             data = websocket.receive_json()
             assert data["event"] == "debt_tick"
             assert data["debt"] == "0.50"
+
+        main_mod._loop = None
+
+
+# ---------------------------------------------------------------------------
+# API endpoints for GitHub Actions cron jobs
+# ---------------------------------------------------------------------------
+
+class TestDebtTickEndpoint:
+    """Test the /api/debt/tick endpoint."""
+
+    def test_debt_tick_endpoint_works(self):
+        from fastapi.testclient import TestClient
+        import main as main_mod
+
+        @main_mod.asynccontextmanager
+        async def _noop_lifespan(app):
+            yield
+
+        test_app = main_mod.FastAPI(title="test", lifespan=_noop_lifespan)
+        test_app.router.routes.extend(main_mod.app.router.routes)
+
+        store = InMemoryStore()
+        loop = main_mod.SurvivalLoop(persistence=store)
+        main_mod._loop = loop
+
+        client = TestClient(test_app)
+        resp = client.post("/api/debt/tick")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["skipped"] is False
+        assert body["debt"] == "0.50"
+        assert body["alive"] is True
+        assert body["life_number"] == 1
+
+        main_mod._loop = None
+
+    def test_debt_tick_deduplication(self):
+        """Test that ticks within 23 hours are deduplicated."""
+        from fastapi.testclient import TestClient
+        import main as main_mod
+
+        @main_mod.asynccontextmanager
+        async def _noop_lifespan(app):
+            yield
+
+        test_app = main_mod.FastAPI(title="test", lifespan=_noop_lifespan)
+        test_app.router.routes.extend(main_mod.app.router.routes)
+
+        store = InMemoryStore()
+        loop = main_mod.SurvivalLoop(persistence=store)
+        main_mod._loop = loop
+
+        client = TestClient(test_app)
+
+        # First tick
+        resp1 = client.post("/api/debt/tick")
+        assert resp1.status_code == 200
+        assert resp1.json()["skipped"] is False
+
+        # Second tick immediately - should be deduplicated
+        resp2 = client.post("/api/debt/tick")
+        assert resp2.status_code == 200
+        body2 = resp2.json()
+        assert body2["skipped"] is True
+        assert "tick already performed recently" in body2["reason"]
+        assert body2["debt"] == "0.50"
+
+        main_mod._loop = None
+
+
+class TestResearchTriggerEndpoint:
+    """Test the /api/research/trigger endpoint."""
+
+    def test_research_trigger_endpoint_works(self):
+        from fastapi.testclient import TestClient
+        import main as main_mod
+        from unittest.mock import AsyncMock
+
+        @main_mod.asynccontextmanager
+        async def _noop_lifespan(app):
+            yield
+
+        test_app = main_mod.FastAPI(title="test", lifespan=_noop_lifespan)
+        test_app.router.routes.extend(main_mod.app.router.routes)
+
+        store = InMemoryStore()
+        loop = main_mod.SurvivalLoop(persistence=store)
+        loop.research.research_earning_platforms = AsyncMock(return_value=[])
+        main_mod._loop = loop
+
+        client = TestClient(test_app)
+        resp = client.post("/api/research/trigger")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "completed"
+        assert "topics_researched" in body
 
         main_mod._loop = None


### PR DESCRIPTION
Closes #21

Migrates the in-process APScheduler debt_tick/research_trigger jobs to GitHub Actions cron workflows so they survive Render free-tier sleep (15 min idle).

## Changes
- `/api/debt/tick` and `/api/research/trigger` endpoints in `main.py`, deduplicated on `last_tick_at` so the cron and the live app's APScheduler jobs never double-charge debt.
- `last_tick_at` added to `DebtState` and persisted via `src/persistence.py` (Supabase/InMemory).
- `scripts/debt_tick.py` + `scripts/research_trigger.py` standalone entrypoints that persist directly to Supabase, independent of the web process.
- `.github/workflows/debt_clock.yml` (daily) and `.github/workflows/research.yml` (every 6h).
- Tests for both endpoints and dedup behaviour in `tests/test_main_loop.py`.

## Verification
- `pytest tests/` → 223 passed.
- `ruff` introduces no new fatal (F401/F841) lint errors beyond pre-existing repo debt.