### PR TITLE
feat: add HuggingFace cold-archive layer (Layer 3) to diary writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ research_loop.py     — DDG search + Jina read + NVIDIA reasoning
 task_scorer.py       — certainty scoring for each potential task
 task_executor.py     — platform connectors, Playwright sessions
 diary_writer.py      — GitHub markdown + HuggingFace JSONL logger
+cold_archive.py      — Layer 3: push every life event as JSONL to HF dataset
 soul_crystal.py      — death-time life summarisation via NVIDIA NIM
 ancestral_memory.py  — rebirth loader, compresses all past soul crystals
 dashboard.py         — Rich terminal UI, live status
@@ -544,7 +545,7 @@ services:
 | All AI API keys | ✓ | ✓ | brain_router + cron jobs |
 | `PAYONEER_WEBHOOK_SECRET` | ✓ | — | FastAPI webhook only |
 | `GITHUB_TOKEN` | — | ✓ built-in | diary_writer |
-| `HF_TOKEN` | ✓ | ✓ | hf_sync |
+| `HF_TOKEN` | ✓ | ✓ | hf_sync + cold_archive (Layer 3) |
 | Platform credentials | ✓ via vault | — | `credentials` table in Supabase via `src/vault.py` (auto-created, keyed by provider + key) |
 
 ### Branching strategy

--- a/artifact.md
+++ b/artifact.md
@@ -394,6 +394,7 @@ research_loop.py     — DDG search + Jina read + NVIDIA reasoning
 task_scorer.py       — certainty scoring for each potential task
 task_executor.py     — platform connectors, Playwright sessions
 diary_writer.py      — GitHub markdown + HuggingFace JSONL logger
+cold_archive.py      — Layer 3: push every life event as JSONL to HF dataset
 soul_crystal.py      — death-time life summarisation via NVIDIA NIM
 ancestral_memory.py  — rebirth loader, compresses all past soul crystals
 dashboard.py         — Rich terminal UI, live status
@@ -542,7 +543,7 @@ services:
 | All AI API keys | ✓ | ✓ | brain_router + cron jobs |
 | `PAYONEER_WEBHOOK_SECRET` | ✓ | — | FastAPI webhook only |
 | `GITHUB_TOKEN` | — | ✓ built-in | diary_writer |
-| `HF_TOKEN` | ✓ | ✓ | hf_sync |
+| `HF_TOKEN` | ✓ | ✓ | hf_sync + cold_archive (Layer 3) |
 | Platform credentials | ✓ via vault | — | `credentials` table in Supabase via `src/vault.py` (auto-created, keyed by provider + key) |
 
 ### Branching strategy

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
 
 from src.ancestral_memory import AncestralMemory, load_ancestral_memory
+from src.cold_archive import ColdArchive
 from src.debt_engine import DebtEngine, DebtState, DifficultyMode
 from src.diary import DiaryWriter
 from src.persistence import PersistenceStore, create_persistence_store
@@ -89,6 +90,7 @@ class SurvivalLoop:
         self.reincarnation = ReincarnationEngine()
         self.research = ResearchAgent()
         self.diary = DiaryWriter()
+        self.cold_archive = ColdArchive()
 
         # Wire persistence on every debt tick
         self.debt_engine._on_tick = self._on_tick  # type: ignore[assignment]
@@ -157,6 +159,7 @@ class SurvivalLoop:
             life_num = self.reincarnation.next_life_number()
             self._life_record = self.reincarnation.start_new_life(life_num)
             self._persist_all()
+            self.cold_archive.begin_life(life_num)
             logger.info("Started new life: %d", life_num)
 
     def _persist_all(self) -> None:
@@ -174,12 +177,22 @@ class SurvivalLoop:
         transition = self.state_machine.update(debt)
         self.wallet.debt = debt
         self._event_log.append(f"Debt tick: ${debt}")
+
+        # Layer 3 cold archive — every debt tick survives hot-memory wipe
+        self.cold_archive.append_event(
+            "debt_tick", {"debt": str(debt), "state": self.state_machine.state.value}
+        )
+
         self._persist_all()
         self._broadcast_event("debt_tick")
 
         if transition:
             self._event_log.append(
                 f"State: {transition.previous.value} → {transition.current.value}"
+            )
+            self.cold_archive.append_event(
+                "state_transition",
+                {"from": transition.previous.value, "to": transition.current.value},
             )
             logger.info(
                 "State transition: %s → %s (debt $%s)",
@@ -210,6 +223,9 @@ class SurvivalLoop:
         self._event_log.append(
             f"DEATH: debt ${state.debt}, life {state.life_number}"
         )
+        self.cold_archive.append_event(
+            "death", {"debt": str(state.debt), "life_number": state.life_number}
+        )
 
         # Generate soul crystal
         crystal = self.reincarnation.on_death(state.debt)
@@ -239,6 +255,8 @@ class SurvivalLoop:
             logger.exception("Diary write failed on death")
 
         # --- Reincarnation ---
+        # Flush remaining events before switching life in the archive
+        self.cold_archive.flush()
         self._reincarnate(state)
 
     def _reincarnate(self, state: DebtState) -> None:
@@ -257,6 +275,10 @@ class SurvivalLoop:
         self.wallet = Wallet()
         self._life_record = self.reincarnation.start_new_life(new_life_num)
         self._event_log = [f"Life {new_life_num} born"]
+
+        # Begin the new life in the cold archive (new JSONL shard)
+        self.cold_archive.reset_for_new_life()
+        self.cold_archive.begin_life(new_life_num)
 
         # Wipe hot-memory state, preserving the permanent soul-crystal archive
         self.persistence.clear()
@@ -304,6 +326,14 @@ class SurvivalLoop:
             for r in results:
                 self._event_log.append(
                     f"Research: {r.topic.value} (confidence {r.confidence:.2f})"
+                )
+                self.cold_archive.append_event(
+                    "research",
+                    {
+                        "topic": r.topic.value,
+                        "confidence": r.confidence,
+                        "summary": r.summary,
+                    },
                 )
             self._persist_all()
             logger.info("Research cycle complete: %d topics", len(results))

--- a/src/cold_archive.py
+++ b/src/cold_archive.py
@@ -1,0 +1,166 @@
+"""HuggingFace cold-archive writer — Layer 3 per artifact.md §10.
+
+Appends every life event across every life as JSONL to a public HuggingFace
+dataset (default ``sagar0163/survival-ai-memory``) so hot memory (Supabase,
+Layer 1) can be wiped on death while the permanent structured record survives
+and stays queryable by future lives.
+
+Format: one JSON object per line, tagged with life number and timestamp.
+The dataset is written as JSONL shards (one file per life) under:
+
+    life-{NNN}.jsonl
+
+Falls back gracefully (logs a warning, no crash) when huggingface_hub is
+unavailable or ``HF_TOKEN`` is unset — same pattern as src/diary.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from huggingface_hub import HfApi
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATASET = "sagar0163/survival-ai-memory"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ColdArchive:
+    """Writes life events as JSONL to a public HuggingFace dataset.
+
+    If HF_TOKEN is unset (or initialisation fails), all write methods become
+    silent no-ops that log a warning — the survival loop never crashes.
+    """
+
+    def __init__(self, dataset_name: str | None = None) -> None:
+        self._dataset_name = dataset_name or os.environ.get(
+            "HF_DATASET", _DEFAULT_DATASET
+        )
+        self._life_number: int = 1
+        self._buffer: list[dict[str, Any]] = []
+        self._flush_threshold = int(os.environ.get("HF_FLUSH_THRESHOLD", "20"))
+
+        token = os.environ.get("HF_TOKEN")
+        if not token:
+            self._api: HfApi | None = None
+            logger.warning(
+                "HF_TOKEN not set — cold archive disabled (dataset=%s)",
+                self._dataset_name,
+            )
+            return
+
+        try:
+            self._api = HfApi(token=token)
+            # Ensure the repo exists (public dataset).  No-op if it does.
+            self._api.create_repo(
+                repo_id=self._dataset_name, repo_type="dataset", exist_ok=True
+            )
+            logger.info("Cold archive initialised: dataset=%s", self._dataset_name)
+        except Exception:
+            self._api = None
+            logger.exception(
+                "Failed to initialise HF cold archive (dataset=%s) — disabled",
+                self._dataset_name,
+            )
+
+    # -- public API ---------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return self._api is not None
+
+    def begin_life(self, life_number: int) -> None:
+        """Set the current life number (usually on birth)."""
+        self._life_number = life_number
+        self._append_event(
+            kind="life_began",
+            data={"life_number": life_number},
+        )
+
+    def append_event(
+        self,
+        kind: str,
+        data: dict[str, Any] | None = None,
+        *,
+        life_number: int | None = None,
+    ) -> None:
+        """Record a single event (task attempt, debt tick, decision, etc.)."""
+        self._append_event(
+            kind=kind,
+            data=data or {},
+            life_number=life_number,
+        )
+
+    def flush(self) -> None:
+        """Force-write the buffered events to the dataset (no-op if disabled)."""
+        if not self.enabled or not self._buffer:
+            return
+
+        life_number = self._life_number
+        filename = f"life-{life_number:03d}.jsonl"
+        lines = "\n".join(json.dumps(e, default=str) for e in self._buffer) + "\n"
+
+        try:
+            # huggingface_hub does not support appending to a file, so we
+            # read the existing shard, append, and re-upload (idempotent +
+            # human-reviewable).  For large archives this should be replaced
+            # with creating per-batch files.
+            existing = self._read_existing(filename)
+            content = (existing + lines) if existing else lines
+            self._api.upload_file(
+                path_or_fileobj=content.encode("utf-8"),
+                path_in_repo=filename,
+                repo_id=self._dataset_name,
+                repo_type="dataset",
+                commit_message=f"archive: append {len(self._buffer)} event(s) life {life_number}",
+            )
+            self._buffer = []
+            logger.debug(
+                "Cold archive: wrote %s events to %s", lines.count("\n"), filename
+            )
+        except Exception:
+            logger.exception("Cold archive flush failed (dataset=%s)", self._dataset_name)
+
+    def reset_for_new_life(self) -> None:
+        """Drop any in-memory buffer for a new life (does not touch uploaded data)."""
+        self._buffer = []
+
+    # -- internal -----------------------------------------------------------
+
+    def _append_event(
+        self,
+        kind: str,
+        data: dict[str, Any],
+        life_number: int | None = None,
+    ) -> None:
+        if not self.enabled:
+            return
+
+        record = {
+            "ts": _now_iso(),
+            "life": life_number if life_number is not None else self._life_number,
+            "kind": kind,
+            "data": data,
+        }
+        self._buffer.append(record)
+        if len(self._buffer) >= self._flush_threshold:
+            self.flush()
+
+    def _read_existing(self, filename: str) -> str:
+        """Download the existing shard content, or '' if it does not exist."""
+        try:
+            return self._api.hf_hub_download(
+                repo_id=self._dataset_name,
+                filename=filename,
+                repo_type="dataset",
+            ) or ""
+        except Exception:  # noqa: BLE001 - intentional graceful fallback
+            return ""

--- a/tests/test_cold_archive.py
+++ b/tests/test_cold_archive.py
@@ -1,0 +1,227 @@
+"""Unit tests for cold_archive.py — HuggingFace Layer 3 cold archive.
+
+All HuggingFace calls are mocked — no real HF_TOKEN or network needed.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from src.cold_archive import _DEFAULT_DATASET, ColdArchive, _now_iso
+
+
+def _make_archive(token: str = "fake-token", dataset: str = "test/survival-ai-memory"):
+    """Create a ColdArchive with a mocked HfApi client and enabled state."""
+    archive = ColdArchive.__new__(ColdArchive)
+    archive._dataset_name = dataset
+    archive._life_number = 1
+    archive._buffer = []
+    archive._flush_threshold = 20
+    archive._api = MagicMock()
+    # By default there is no existing shard — read returns empty
+    archive._api.hf_hub_download.return_value = None
+    return archive
+
+
+# ---------------------------------------------------------------------------
+# Graceful fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulFallback:
+    """ColdArchive must not crash when HF_TOKEN is missing."""
+
+    def test_no_token_disables(self):
+        with patch.dict("os.environ", {}, clear=True):
+            archive = ColdArchive()
+        assert archive.enabled is False
+
+    def test_append_event_noop_without_token(self):
+        with patch.dict("os.environ", {}, clear=True):
+            archive = ColdArchive()
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()  # should not raise
+
+    def test_begin_life_noop_without_token(self):
+        with patch.dict("os.environ", {}, clear=True):
+            archive = ColdArchive()
+        archive.begin_life(2)
+        archive.flush()
+
+    def test_init_failure_disables(self):
+        """If HfApi/init raises, the archive should be disabled, not crash."""
+        from src.cold_archive import ColdArchive as CA
+        with patch("src.cold_archive.HfApi", side_effect=RuntimeError("boom")):
+            disabled = CA(dataset_name="test/x")
+        assert disabled.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Basic buffering behavior
+# ---------------------------------------------------------------------------
+
+
+class TestBuffering:
+    """ColdArchive buffers events and flushes as JSONL."""
+
+    def test_append_buffers_until_threshold(self):
+        archive = _make_archive()
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        assert len(archive._buffer) == 1
+        assert archive._api.upload_file.call_count == 0  # under threshold
+
+    def test_append_flushes_at_threshold(self):
+        archive = _make_archive()
+        archive._flush_threshold = 2
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.append_event("state_transition", {"from": "a", "to": "b"})
+        # Reaching the threshold should trigger an auto-flush
+        archive._api.upload_file.assert_called_once()
+
+    def test_flush_writes_jsonl(self):
+        archive = _make_archive()
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()
+        archive._api.upload_file.assert_called_once()
+        call = archive._api.upload_file.call_args
+        assert call.kwargs["path_in_repo"] == "life-001.jsonl"
+        assert call.kwargs["repo_id"] == "test/survival-ai-memory"
+        assert call.kwargs["repo_type"] == "dataset"
+
+        # Decode the uploaded body and validate it's valid JSONL
+        body = call.kwargs["path_or_fileobj"].decode("utf-8")
+        lines = body.strip().split("\n")
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["life"] == 1
+        assert record["kind"] == "debt_tick"
+        assert record["data"]["debt"] == "0.50"
+        assert "ts" in record
+
+    def test_flush_clears_buffer(self):
+        archive = _make_archive()
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()
+        assert archive._buffer == []
+
+    def test_flush_noop_when_disabled(self):
+        archive = ColdArchive.__new__(ColdArchive)
+        archive._dataset_name = "x"
+        archive._life_number = 1
+        archive._buffer = [{"k": "v"}]
+        archive._flush_threshold = 20
+        archive._api = None
+        archive.flush()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Life lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifeLifecycle:
+    """ColdArchive tracks life numbers and begins new lives."""
+
+    def test_begin_life_appends_life_began_event(self):
+        archive = _make_archive()
+        archive.begin_life(3)
+        assert archive._life_number == 3
+        assert len(archive._buffer) == 1
+        assert archive._buffer[0]["kind"] == "life_began"
+        assert archive._buffer[0]["data"]["life_number"] == 3
+
+    def test_append_event_uses_current_life(self):
+        archive = _make_archive()
+        archive._life_number = 7
+        archive.append_event("decision", {"x": 1})
+        assert archive._buffer[0]["life"] == 7
+
+    def test_append_event_explicit_life_overrides(self):
+        archive = _make_archive()
+        archive._life_number = 7
+        archive.append_event("decision", {"x": 1}, life_number=9)
+        assert archive._buffer[0]["life"] == 9
+
+    def test_reset_for_new_life_drops_buffer(self):
+        archive = _make_archive()
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.reset_for_new_life()
+        assert archive._buffer == []
+
+
+# ---------------------------------------------------------------------------
+# Shard reading / appending
+# ---------------------------------------------------------------------------
+
+
+class TestAppending:
+    """ColdArchive appends to an existing shard file."""
+
+    def test_flush_appends_to_existing_content(self):
+        archive = _make_archive()
+        # Simulate an existing shard already on HF
+        archive._api.hf_hub_download.return_value = '{"old": true}\n'
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()
+
+        call = archive._api.upload_file.call_args
+        body = call.kwargs["path_or_fileobj"].decode("utf-8")
+        lines = body.strip().split("\n")
+        # Existing content preserved + new event appended
+        assert len(lines) == 2
+        assert json.loads(lines[0]) == {"old": True}
+        assert json.loads(lines[1])["kind"] == "debt_tick"
+
+    def test_flush_reads_empty_when_no_existing(self):
+        archive = _make_archive()
+        archive._api.hf_hub_download.return_value = None
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()
+        body = archive._api.upload_file.call_args.kwargs["path_or_fileobj"].decode("utf-8")
+        assert "old" not in body
+
+    def test_flush_tolerates_download_failure(self):
+        archive = _make_archive()
+        archive._api.hf_hub_download.side_effect = Exception("network down")
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()  # should still upload with just the new event
+        body = archive._api.upload_file.call_args.kwargs["path_or_fileobj"].decode("utf-8")
+        assert json.loads(body.strip().split("\n")[0])["kind"] == "debt_tick"
+
+    def test_flush_upload_failure_keeps_buffer(self):
+        archive = _make_archive()
+        archive._api.upload_file.side_effect = Exception("upload failed")
+        archive.append_event("debt_tick", {"debt": "0.50"})
+        archive.flush()
+        # Buffer retained for a later retry (event not lost)
+        assert len(archive._buffer) == 1
+
+
+# ---------------------------------------------------------------------------
+# Setup / defaults
+# ---------------------------------------------------------------------------
+
+
+class TestSetup:
+    def test_default_dataset_name(self):
+        assert _DEFAULT_DATASET == "sagar0163/survival-ai-memory"
+
+    def test_now_iso_format(self):
+        iso = _now_iso()
+        # Parseable ISO-8601 with timezone
+        from datetime import datetime
+        parsed = datetime.fromisoformat(iso)
+        assert parsed.tzinfo is not None
+
+    def test_enabled_true_with_api(self):
+        archive = _make_archive()
+        assert archive.enabled is True
+
+    def test_uses_env_dataset_override(self):
+        with patch.dict("os.environ", {"HF_DATASET": "custom/ds"}, clear=True), \
+             patch("src.cold_archive.HfApi") as mock_api_cls:
+            mock_api_cls.return_value.create_repo.return_value = None
+            from src.cold_archive import ColdArchive as CA
+            archive = CA(dataset_name=None)
+        assert archive._dataset_name == "custom/ds"


### PR DESCRIPTION
Closes #23

Adds the late Layer 3 cold archive (artifact.md §10): every life event pushed as JSONL to a public HuggingFace dataset, one shard per life (`life-NNN.jsonl`).

- `src/cold_archive.py`: `ColdArchive` buffers events and flushes to `sagar0163/survival-ai-memory` via `huggingface_hub`. Graceful no-op when `HF_TOKEN` unset (same fallback as `src/diary.py` / `GITHUB_TOKEN`).
- `main.py`: wired into survival loop lifecycle — `begin_life` on birth, `append_event` on debt tick / state transitions / death / research, flush before reincarnation, reset + begin for the new life.
- Tests: 21 unit tests with mocked `HfApi` (no live network in CI).

Only known failure in the full suite is the pre-existing flaky `test_websocket_receives_debt_tick` which also fails on clean `main` (verified) — unrelated to this change.