### PR TITLE
feat: add task timeout cap while debt keeps ticking

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ dashboard.py         — Rich terminal UI, live status
 | 🟡 | Human approval gate | User confirm before AI spends from free pool? |
 | 🟡 | Audit trail | Every decision logged with full reasoning |
 | 🟡 | Alert system | Notify user at Critical/Terminal (email? SMS?) |
-| 🟡 | Task timeout | Max duration cap while debt keeps ticking |
+| ✅ | Task timeout | **SOLVED** — `asyncio.wait_for` cap in `TaskExecutor.execute_task` (default 300s); excess → failed result, $0 credit |
 
 ---
 

--- a/artifact.md
+++ b/artifact.md
@@ -434,7 +434,7 @@ dashboard.py         — Rich terminal UI, live status
 | 🟡 | Human approval gate | User confirm before AI spends from free pool? |
 | 🟡 | Audit trail | Every decision logged with full reasoning |
 | 🟡 | Alert system | Notify user at Critical/Terminal (email? SMS?) |
-| 🟡 | Task timeout | Max duration cap while debt keeps ticking |
+| ✅ | Task timeout | **SOLVED** — `asyncio.wait_for` cap in `TaskExecutor.execute_task` (default 300s); excess → failed result, $0 credit |
 
 ---
 

--- a/src/task_executor.py
+++ b/src/task_executor.py
@@ -46,9 +46,19 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_SESSION_DIR = ".uj_sessions"
 
+# artifact.md §14: "Task timeout — Max duration cap while debt keeps ticking".
+# Default cap: a task may run at most this long before we abort it and report
+# failure. Debt keeps accruing meanwhile, so an unbounded task is a slow leak.
+DEFAULT_TASK_TIMEOUT_SECONDS = 300
+
 
 class ExecutionError(Exception):
     """Raised when task execution fails."""
+    pass
+
+
+class TaskTimeoutError(ExecutionError):
+    """Raised when a task exceeds its maximum allowed duration."""
     pass
 
 
@@ -761,12 +771,14 @@ class TaskExecutor:
         session_dir: Optional[str] = None,
         vault: Optional[CredentialsVault] = None,
         guardrail: EthicalGuardrail | None = None,
+        task_timeout_seconds: float = DEFAULT_TASK_TIMEOUT_SECONDS,
     ) -> None:
         self.wallet = wallet
         self.headless = headless
         self.max_concurrent_tasks = max_concurrent_tasks
         # Hard blacklist double-check runs immediately before execution.
         self.guardrail = guardrail or get_guardrail()
+        self.task_timeout_seconds = task_timeout_seconds
         self.session_manager = BrowserSessionManager(
             headless=headless, storage_dir=session_dir
         )
@@ -866,6 +878,10 @@ class TaskExecutor:
     ) -> TaskResult:
         """Execute a single task and credit earnings to wallet.
 
+        Enforces ``self.task_timeout_seconds`` — a hard cap on task duration so
+        a stuck task can't run indefinitely while debt keeps ticking (artifact.md
+        §14 "Task timeout"). On timeout the task is reported as failed with $0.
+
         Args:
             candidate: The task to execute.
             certainty: ROI certainty for wallet spend gate (default 95%).
@@ -897,8 +913,26 @@ class TaskExecutor:
 
         connector = await self._get_connector(candidate.platform)
 
-        # Execute the task
-        result = await connector.execute_task(candidate)
+        # Execute the task, capped to prevent unbounded runtime while debt accrues
+        try:
+            result = await asyncio.wait_for(
+                connector.execute_task(candidate),
+                timeout=self.task_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Task {candidate.title!r} exceeded {self.task_timeout_seconds}s cap; "
+                "aborting and reporting failure"
+            )
+            result = TaskResult(
+                task_id=str(uuid.uuid4())[:8],
+                candidate=candidate,
+                success=False,
+                amount_earned=Decimal("0"),
+                time_spent_hours=Decimal("0"),
+                error=f"Task timed out after {self.task_timeout_seconds}s",
+                platform_data={"platform": candidate.platform.value, "timed_out": True},
+            )
 
         # If successful, credit earnings to wallet free pool
         if result.success and result.amount_earned > 0:

--- a/tests/test_task_scorer_executor.py
+++ b/tests/test_task_scorer_executor.py
@@ -1172,6 +1172,53 @@ class TestTaskExecutor:
         mock_wallet.credit_earned.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_execute_task_times_out(self, executor, mock_wallet):
+        """Test that a task exceeding the duration cap is aborted and fails.
+
+        artifact.md §14 "Task timeout" — a stuck task must not run indefinitely
+        while debt keeps ticking, so the executor reports failure with $0.
+        """
+        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_executor import ClickworkerConnector
+
+        async def _stuck_execute_task(candidate):
+            await asyncio.sleep(30)  # far longer than any sane cap
+
+        mock_connector = AsyncMock(spec=ClickworkerConnector)
+        mock_connector.execute_task = AsyncMock(side_effect=_stuck_execute_task)
+
+        executor._connectors[Platform.CLICKWORKER] = mock_connector
+        executor.task_timeout_seconds = 0.05  # tiny cap to force a timeout quickly
+
+        candidate = TaskCandidate(
+            platform=Platform.CLICKWORKER,
+            task_type=TaskType.MICROTASK,
+            title="Stuck task",
+            estimated_pay=Decimal("10.00"),
+            estimated_hours=Decimal("1.0"),
+            payment_method=PaymentMethod.PAYONEER,
+        )
+
+        await executor.start()
+        result = await executor.execute_task(candidate)
+        await executor.stop()
+
+        assert result.success is False
+        assert result.amount_earned == Decimal("0")
+        assert result.error is not None
+        assert "timed out" in result.error
+        assert result.platform_data.get("timed_out") is True
+        mock_wallet.credit_earned.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_task_respects_default_timeout(self, executor, mock_wallet):
+        """Test that the default task timeout is applied when not overridden."""
+        from src.task_executor import DEFAULT_TASK_TIMEOUT_SECONDS
+
+        assert executor.task_timeout_seconds == DEFAULT_TASK_TIMEOUT_SECONDS
+        assert executor.task_timeout_seconds > 0
+
+    @pytest.mark.asyncio
     async def test_execute_batch(self, executor, mock_wallet):
         """Test executing batch of tasks."""
         from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskResult, TaskType

--- a/tests/test_task_scorer_executor.py
+++ b/tests/test_task_scorer_executor.py
@@ -1178,8 +1178,10 @@ class TestTaskExecutor:
         artifact.md §14 "Task timeout" — a stuck task must not run indefinitely
         while debt keeps ticking, so the executor reports failure with $0.
         """
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        import asyncio
+
         from src.task_executor import ClickworkerConnector
+        from src.task_scorer import TaskCandidate
 
         async def _stuck_execute_task(candidate):
             await asyncio.sleep(30)  # far longer than any sane cap


### PR DESCRIPTION
Closes #37

## Summary
Implements artifact.md §14 🟡 **Task timeout** — "Max duration cap while debt keeps ticking".

Adds a configurable max task execution duration to `TaskExecutor`. If a platform task runs beyond the cap, it is aborted and reported as failed with $0 credited, so the agent never burns unbounded time (while debt keeps accruing) on a stuck task.

## Changes
- `src/task_executor.py`
  - Add `DEFAULT_TASK_TIMEOUT_SECONDS = 300` and `TaskTimeoutError`
  - Add `task_timeout_seconds` param to `TaskExecutor.__init__`
  - Wrap `connector.execute_task` in `asyncio.wait_for` in `execute_task`
  - On timeout: failed `TaskResult`, $0, `error` set, `timed_out: true` in `platform_data`, no wallet credit
  - Mechanical ruff cleanup in this file (import sorting, dropped unused `SpendRequest` import)
- `tests/test_task_scorer_executor.py`
  - `test_execute_task_times_out`: stuck task aborted, failed, $0, no wallet credit
  - `test_execute_task_respects_default_timeout`: default cap applied
- `artifact.md` 0.7: Task timeout gap → **SOLVED**; regenerated README

## Verification
- `pytest tests/test_task_scorer_executor.py`: 46 passed
- Full suite (minus pre-existing flaky WS test fixed in #36): 221 passed
- `ruff check src/task_executor.py`: clean