### PR TITLE
fix(persistence): make Supabase save_events replace instead of append

### DIFF
--- a/src/persistence.py
+++ b/src/persistence.py
@@ -346,6 +346,9 @@ class SupabaseStore(PersistenceStore):
     # -- events -------------------------------------------------------------
 
     def save_events(self, events: list[str]) -> None:
+        # Replace, not append: _persist_all() calls save_events with the full
+        # event log on every tick, so appending would duplicate rows quadratically.
+        self._delete_all("events")
         for ev in events:
             self._append("events", {"text": ev})
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -181,6 +181,20 @@ class TestInMemoryStore:
         loaded = store.load_events()
         assert loaded == ["tick 1", "tick 2", "death"]
 
+    def test_events_save_replaces_not_appends(self, store):
+        # _persist_all() re-saves the full growing log on every tick; a
+        # second save of a superset must not duplicate the earlier rows.
+        store.save_events(["tick 1"])
+        store.save_events(["tick 1", "tick 2"])
+        store.save_events(["tick 1", "tick 2", "tick 3"])
+        assert store.load_events() == ["tick 1", "tick 2", "tick 3"]
+
+    def test_events_save_shrinks_list(self, store):
+        # Replacing with a shorter list must drop the stale rows.
+        store.save_events(["a", "b", "c"])
+        store.save_events(["a"])
+        assert store.load_events() == ["a"]
+
     def test_events_load_empty(self, store):
         assert store.load_events() == []
 


### PR DESCRIPTION
Closes #45

`_persist_all()` (called on every debt tick) re-saves the full event log via
`save_events`, so `SupabaseStore`'s append-only behavior grew the Supabase
`events` table quadratically over ticks and produced duplicate rows. This aligns
`SupabaseStore.save_events` with `InMemoryStore` and the documented semantics:
persist exactly the given list (idempotent replace), so `load_events` returns it
and nothing else.

- `src/persistence.py`: clear prior event rows before inserting the list
- `tests/test_persistence.py`:\n  - `test_events_save_replaces_not_appends` (repeated saves must not duplicate)\n  - `test_events_save_shrinks_list` (saving a shorter list drops stale rows)\n\nFull suite: 220 passed, only the 2 known pre-existing flaky tests fail
(`test_websocket_receives_debt_tick`, `test_full_cycle_mock` — unrelated to this
change). New lines ruff-clean.