### PR TITLE
fix(lint): add .ruff.toml and sweep repo lint debt so ruff passes on main

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,9 @@
+line-length = 120
+target-version = "py312"
+
+[lint]
+# Curated set per artifact.md §16: pyflakes (F), pycodestyle basics,
+# import sorting (I). F811 (redefined-while-unused) is intentionally
+# ignored — it fires heavily on test fixtures and is not a real defect.
+select = ["E", "F", "I"]
+ignore = ["F811"]

--- a/src/brain_router.py
+++ b/src/brain_router.py
@@ -9,16 +9,16 @@ Routing logic:
 
 from __future__ import annotations
 
-import os
 import asyncio
 import logging
-from enum import Enum
-from typing import Optional, List, Dict, Any
-from dataclasses import dataclass, field
+import os
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/src/debt_engine.py
+++ b/src/debt_engine.py
@@ -9,7 +9,7 @@ Rules from artifact.md §4 & §11:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Callable, Optional

--- a/src/diary.py
+++ b/src/diary.py
@@ -17,7 +17,7 @@ import json
 import logging
 import os
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any
 
 from github import Github, GithubException, UnknownObjectException
 from pydantic import BaseModel

--- a/src/research_loop.py
+++ b/src/research_loop.py
@@ -6,26 +6,23 @@ Research gate: Tasks score >0.85 certainty to enter queue (relaxed in Critical/T
 
 from __future__ import annotations
 
-import os
 import asyncio
 import json
 import logging
 import re
-from datetime import datetime, timedelta
-from typing import Optional, List, Dict, Any
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
-from urllib.parse import quote_plus
+from typing import Any, Dict, List, Optional
 
 import httpx
-from pydantic import BaseModel, Field
 from duckduckgo_search import DDGS
+from pydantic import BaseModel
 
 from src.brain_router import (
-    get_brain_router,
     CompletionRequest,
     TaskType,
-    Provider,
+    get_brain_router,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 from enum import Enum
-from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class State(str, Enum):

--- a/src/task_executor.py
+++ b/src/task_executor.py
@@ -16,18 +16,17 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from decimal import Decimal
 from typing import Optional
-from dataclasses import dataclass, field
 
-from playwright.async_api import async_playwright, Browser, BrowserContext, Page
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 
 from src.task_scorer import (
+    PaymentMethod,
+    Platform,
     TaskCandidate,
     TaskResult,
-    Platform,
     TaskType,
-    PaymentMethod,
 )
-from src.wallet import Wallet, SpendRequest
+from src.wallet import Wallet
 
 logger = logging.getLogger(__name__)
 

--- a/src/task_scorer.py
+++ b/src/task_scorer.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 from decimal import Decimal
 from enum import Enum
 from typing import Optional
-from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
 
-from src.state_machine import State, resolve_state, min_certainty, risk_tolerance
+from src.state_machine import State, min_certainty, resolve_state
 
 
 class Platform(str, Enum):
@@ -60,7 +59,8 @@ PLATFORM_DATA: dict[Platform, tuple[Decimal, Decimal, PaymentMethod, bool]] = {
     Platform.TOLOKA: (Decimal("0.75"), Decimal("20"), PaymentMethod.PAYONEER, True),
     Platform.CLICKWORKER: (Decimal("0.70"), Decimal("30"), PaymentMethod.PAYONEER, True),
     Platform.PROLIFIC: (Decimal("0.70"), Decimal("50"), PaymentMethod.PAYPAL, True),
-    Platform.APPEN: (Decimal("0.65"), Decimal("200"), PaymentMethod.PAYONEER, False),  # Project-based, less automation-friendly
+    # Project-based, less automation-friendly
+    Platform.APPEN: (Decimal("0.65"), Decimal("200"), PaymentMethod.PAYONEER, False),
     Platform.DATA_ANNOTATION: (Decimal("0.65"), Decimal("30"), PaymentMethod.CRYPTO, True),
     Platform.UPWORK: (Decimal("0.55"), Decimal("50"), PaymentMethod.PAYONEER, False),  # High competition
     Platform.FIVERR: (Decimal("0.50"), Decimal("30"), PaymentMethod.PAYONEER, False),  # 20% cut, gig-based
@@ -163,7 +163,6 @@ class TaskScorer:
         """
         state = resolve_state(current_debt)
         threshold = min_certainty(current_debt)
-        risk = risk_tolerance(current_debt)
 
         reasoning = []
 
@@ -174,9 +173,6 @@ class TaskScorer:
             reasoning.append(f"Base platform certainty: {base_certainty} ({candidate.platform.value})")
         else:
             base_certainty = Decimal("0.5")
-            typical_pay = Decimal("0")
-            platform_payment = candidate.payment_method
-            automation_friendly = False
             reasoning.append(f"Unknown platform, using default: {base_certainty}")
 
         # 2. Platform-task affinity bonus
@@ -192,7 +188,11 @@ class TaskScorer:
         reasoning.append(f"Payment method ({candidate.payment_method.value}) bonus: +{payment_bonus}")
 
         # 4. Pay rate bonus (vs minimum threshold)
-        pay_per_hour = candidate.estimated_pay / candidate.estimated_hours if candidate.estimated_hours > 0 else Decimal("0")
+        pay_per_hour = (
+            candidate.estimated_pay / candidate.estimated_hours
+            if candidate.estimated_hours > 0
+            else Decimal("0")
+        )
         pay_rate_bonus = Decimal("0")
         if pay_per_hour >= self.min_pay_per_hour:
             # Up to 0.1 bonus for good pay
@@ -213,7 +213,7 @@ class TaskScorer:
             reasoning.append(f"Surviving state bonus: +{survival_bonus}")
         elif state == State.STRUGGLING:
             survival_bonus = Decimal("0.0")
-            reasoning.append(f"Struggling state: no bonus")
+            reasoning.append("Struggling state: no bonus")
         elif state in (State.CRITICAL, State.TERMINAL):
             survival_bonus = Decimal("0.0")
             reasoning.append(f"{state.value.upper()} state: threshold relaxed to {threshold}")

--- a/src/wallet.py
+++ b/src/wallet.py
@@ -10,10 +10,8 @@ Rules from artifact.md §4:
 from __future__ import annotations
 
 from decimal import Decimal
-from enum import Enum
-from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 
 class WalletError(Exception):

--- a/tests/test_brain_router_and_research.py
+++ b/tests/test_brain_router_and_research.py
@@ -3,12 +3,12 @@
 All HTTP calls are mocked - no real API keys needed.
 """
 
-import os
-import json
 import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, Mock
-from datetime import datetime
 
 # Set dummy env vars before importing modules
 os.environ.setdefault("NVIDIA_API_KEY", "test-nvidia-key")
@@ -116,7 +116,7 @@ class TestRoutingOrder:
     """Test provider routing order logic."""
 
     def test_complex_routing_order(self):
-        from src.brain_router import get_routing_order, TaskType, Provider
+        from src.brain_router import Provider, TaskType, get_routing_order
         order = get_routing_order(TaskType.COMPLEX)
         assert order[0] == Provider.NVIDIA_NIM
         assert order[1] == Provider.CEREBRAS
@@ -124,19 +124,19 @@ class TestRoutingOrder:
         assert Provider.CLOUDFLARE == order[-1]  # Last resort
 
     def test_speed_routing_order(self):
-        from src.brain_router import get_routing_order, TaskType, Provider
+        from src.brain_router import Provider, TaskType, get_routing_order
         order = get_routing_order(TaskType.SPEED)
         assert order[0] == Provider.GROQ
         assert order[1] == Provider.NVIDIA_NIM
 
     def test_high_volume_routing_order(self):
-        from src.brain_router import get_routing_order, TaskType, Provider
+        from src.brain_router import Provider, TaskType, get_routing_order
         order = get_routing_order(TaskType.HIGH_VOLUME)
         assert order[0] == Provider.GEMINI_FLASH
         assert order[1] == Provider.FREE_LLM_API
 
     def test_general_routing_order(self):
-        from src.brain_router import get_routing_order, TaskType, Provider
+        from src.brain_router import Provider, TaskType, get_routing_order
         order = get_routing_order(TaskType.GENERAL)
         assert order[0] == Provider.FREE_LLM_API
 
@@ -146,9 +146,9 @@ class TestBrainRouter:
 
     @pytest.fixture
     def router(self):
-        from src.brain_router import BrainRouter, Provider
         # Reset singleton
         import src.brain_router as br
+        from src.brain_router import BrainRouter
         br._router = None
         return BrainRouter()
 
@@ -161,7 +161,7 @@ class TestBrainRouter:
     @pytest.mark.asyncio
     async def test_complete_success_first_provider(self, router):
         """Test successful completion on first provider."""
-        from src.brain_router import CompletionRequest, CompletionResponse, TaskType, Provider
+        from src.brain_router import CompletionRequest, CompletionResponse, Provider, TaskType
 
         # Mock the NVIDIA client
         mock_client = AsyncMock()
@@ -187,7 +187,7 @@ class TestBrainRouter:
     @pytest.mark.asyncio
     async def test_complete_failover_to_second_provider(self, router):
         """Test failover when first provider fails."""
-        from src.brain_router import CompletionRequest, CompletionResponse, TaskType, Provider
+        from src.brain_router import CompletionRequest, CompletionResponse, Provider, TaskType
 
         # Mock NVIDIA client to fail
         mock_nvidia = AsyncMock()
@@ -226,7 +226,7 @@ class TestBrainRouter:
     @pytest.mark.asyncio
     async def test_complete_all_providers_fail(self, router):
         """Test when all providers fail."""
-        from src.brain_router import CompletionRequest, CompletionResponse, TaskType, Provider
+        from src.brain_router import CompletionRequest, CompletionResponse, Provider, TaskType
 
         mock_client = AsyncMock()
         mock_client.complete.return_value = CompletionResponse(
@@ -251,7 +251,7 @@ class TestConvenienceFunction:
 
     @pytest.mark.asyncio
     async def test_complete_function(self):
-        from src.brain_router import complete, CompletionResponse, Provider, TaskType
+        from src.brain_router import CompletionResponse, Provider, TaskType, complete
 
         with patch("src.brain_router.get_brain_router") as mock_get_router:
             mock_router = AsyncMock()
@@ -437,7 +437,7 @@ class TestResearchAgent:
     @pytest.mark.asyncio
     async def test_research_success(self, agent):
         """Test full research cycle with mocked search, read, and reasoning."""
-        from src.research_loop import ResearchQuery, ResearchTopic, ResearchState
+        from src.research_loop import ResearchQuery, ResearchState, ResearchTopic
 
         # Mock searcher
         mock_search_results = [
@@ -519,7 +519,7 @@ class TestResearchLoop:
 
     @pytest.fixture
     def loop(self):
-        from src.research_loop import ResearchLoop, ResearchAgent
+        from src.research_loop import ResearchAgent, ResearchLoop
         agent = ResearchAgent()
         return ResearchLoop(agent=agent)
 
@@ -557,7 +557,7 @@ class TestQuickResearch:
 
     @pytest.mark.asyncio
     async def test_quick_research(self):
-        from src.research_loop import quick_research, ResearchTopic, ResearchResult
+        from src.research_loop import ResearchResult, ResearchTopic, quick_research
 
         with patch("src.research_loop.ResearchAgent") as MockAgent:
             mock_agent = AsyncMock()
@@ -606,10 +606,7 @@ class TestBrainRouterIntegration:
     @pytest.mark.asyncio
     async def test_full_failover_chain(self):
         """Test complete failover chain: NVIDIA -> Cerebras -> Mistral -> OpenRouter."""
-        from src.brain_router import (
-            BrainRouter, CompletionRequest, CompletionResponse,
-            TaskType, Provider
-        )
+        from src.brain_router import BrainRouter, CompletionRequest, CompletionResponse, Provider, TaskType
 
         router = BrainRouter()
         router._initialized = True

--- a/tests/test_debt_engine.py
+++ b/tests/test_debt_engine.py
@@ -1,15 +1,13 @@
 """Unit tests for debt_engine.py — existence debt accumulation and death trigger."""
 
-import pytest
 from decimal import Decimal
-from datetime import datetime, timedelta
+
+import pytest
 
 from src.debt_engine import (
-    DebtEngine,
-    DebtState,
-    DifficultyMode,
     DEATH_THRESHOLD,
-    DIFFICULTY_PARAMS,
+    DebtEngine,
+    DifficultyMode,
 )
 
 

--- a/tests/test_diary.py
+++ b/tests/test_diary.py
@@ -6,12 +6,10 @@ import json
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-import pytest
 from github import GithubException, UnknownObjectException
 from pydantic import BaseModel
 
 from src.diary import DiaryWriter
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,12 +1,13 @@
 """Integration test: wallet + debt engine + state machine working together."""
 
-import pytest
 from decimal import Decimal
 
-from src.wallet import Wallet, SpendRequest
+import pytest
+
 from src.debt_engine import DebtEngine, DifficultyMode
-from src.state_machine import SurvivalStateMachine, State
 from src.soul_crystal import ReincarnationEngine
+from src.state_machine import State, SurvivalStateMachine
+from src.wallet import SpendRequest, Wallet
 
 
 class TestEndToEndLifecycle:

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -9,7 +9,6 @@ from src.soul_crystal import ReincarnationEngine
 from src.state_machine import State, SurvivalStateMachine
 from src.wallet import Wallet
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -227,6 +226,7 @@ class TestHealthEndpoint:
 
     def test_health_returns_200(self):
         from fastapi.testclient import TestClient
+
         import main as main_mod
 
         # Patch lifespan to avoid starting the real scheduler
@@ -248,6 +248,7 @@ class TestHealthEndpoint:
     def test_health_during_loop(self):
         """The production /health handler returns 200 while the loop is live."""
         from fastapi.testclient import TestClient
+
         import main as main_mod
 
         # Build a fresh app with a no-op lifespan so no scheduler is started,
@@ -328,6 +329,7 @@ class TestStatusEndpoint:
 
     def test_status_returns_200_and_keys(self):
         from fastapi.testclient import TestClient
+
         import main as main_mod
 
         @main_mod.asynccontextmanager
@@ -373,6 +375,7 @@ class TestWebSocketBroadcast:
 
     def test_websocket_receives_debt_tick(self):
         from fastapi.testclient import TestClient
+
         import main as main_mod
 
         @main_mod.asynccontextmanager

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -9,19 +9,18 @@ import pytest
 from src.debt_engine import DebtState, DifficultyMode
 from src.persistence import (
     InMemoryStore,
-    create_persistence_store,
-    _debt_state_to_dict,
     _debt_state_from_dict,
-    _wallet_to_dict,
-    _wallet_from_dict,
-    _life_record_to_dict,
+    _debt_state_to_dict,
     _life_record_from_dict,
-    _soul_crystal_to_dict,
+    _life_record_to_dict,
     _soul_crystal_from_dict,
+    _soul_crystal_to_dict,
+    _wallet_from_dict,
+    _wallet_to_dict,
+    create_persistence_store,
 )
 from src.soul_crystal import LifeRecord, SoulCrystal
 from src.wallet import Wallet
-
 
 # ---------------------------------------------------------------------------
 # Serialisation helpers

--- a/tests/test_soul_crystal.py
+++ b/tests/test_soul_crystal.py
@@ -1,17 +1,17 @@
 """Unit tests for soul_crystal.py — reincarnation logic."""
 
-import pytest
+from datetime import datetime, timezone
 from decimal import Decimal
-from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from src.soul_crystal import (
-    SoulCrystal,
-    DeathLog,
     LifeRecord,
     ReincarnationEngine,
-    generate_soul_crystal,
-    generate_death_log,
+    SoulCrystal,
     build_ancestral_memory,
+    generate_death_log,
+    generate_soul_crystal,
 )
 
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,14 +1,15 @@
 """Unit tests for state_machine.py — survival state transitions."""
 
-import pytest
 from decimal import Decimal
 
+import pytest
+
 from src.state_machine import (
-    SurvivalStateMachine,
     State,
+    SurvivalStateMachine,
+    min_certainty,
     resolve_state,
     risk_tolerance,
-    min_certainty,
 )
 
 

--- a/tests/test_task_scorer_executor.py
+++ b/tests/test_task_scorer_executor.py
@@ -4,12 +4,10 @@ All browser sessions are mocked - no real Playwright or API keys needed.
 """
 
 import os
-import json
-import asyncio
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, Mock
 from decimal import Decimal
-from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 # Set dummy env vars before importing modules
 os.environ.setdefault("NVIDIA_API_KEY", "test-nvidia-key")
@@ -23,15 +21,10 @@ os.environ.setdefault("FREE_LLM_API_KEY", "test-freellm-key")
 
 # Import enums and models needed across tests
 from src.task_scorer import (
+    PaymentMethod,
     Platform,
     TaskType,
-    PaymentMethod,
-    TaskCandidate,
-    TaskScore,
-    TaskResult,
-    TaskScorer,
 )
-from src.state_machine import State
 
 # ============================================================================
 # Test task_scorer.py
@@ -74,7 +67,7 @@ class TestTaskCandidate:
     """Test TaskCandidate model."""
 
     def test_task_candidate_defaults(self):
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
             task_type=TaskType.MICROTASK,
@@ -93,7 +86,7 @@ class TestTaskCandidate:
         assert candidate.metadata == {}
 
     def test_task_candidate_custom(self):
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
         candidate = TaskCandidate(
             platform=Platform.TOLOKA,
             task_type=TaskType.MICROTASK,
@@ -116,8 +109,7 @@ class TestTaskScore:
     """Test TaskScore model."""
 
     def test_task_score_creation(self):
-        from src.task_scorer import TaskScore, TaskCandidate, Platform, TaskType, PaymentMethod, State
-        from src.state_machine import State as SMState
+        from src.task_scorer import PaymentMethod, Platform, State, TaskCandidate, TaskScore, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -147,7 +139,7 @@ class TestPlatformData:
     """Test platform data constants."""
 
     def test_platform_data_exists(self):
-        from src.task_scorer import PLATFORM_DATA, Platform, PaymentMethod
+        from src.task_scorer import PLATFORM_DATA, PaymentMethod, Platform
         assert Platform.TOLOKA in PLATFORM_DATA
         assert Platform.CLICKWORKER in PLATFORM_DATA
         assert Platform.PROLIFIC in PLATFORM_DATA
@@ -175,7 +167,6 @@ class TestTaskScorer:
         return TaskScorer()
 
     def test_scorer_initialization(self, scorer):
-        from src.task_scorer import TaskScorer
         assert scorer.base_threshold == Decimal("0.85")
         assert scorer.min_pay_per_hour == Decimal("1.00")
 
@@ -187,8 +178,8 @@ class TestTaskScorer:
 
     def test_score_clickworker_thriving(self, scorer):
         """Test scoring Clickworker task in Thriving state (debt $0-2)."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
         from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -211,8 +202,8 @@ class TestTaskScorer:
 
     def test_score_clickworker_surviving(self, scorer):
         """Test scoring Clickworker task in Surviving state (debt $2-5)."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
         from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -233,8 +224,8 @@ class TestTaskScorer:
 
     def test_score_clickworker_struggling(self, scorer):
         """Test scoring Clickworker task in Struggling state (debt $5-7.50)."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
         from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -255,8 +246,8 @@ class TestTaskScorer:
 
     def test_score_clickworker_critical(self, scorer):
         """Test scoring Clickworker task in Critical state (debt $7.50-9.50)."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
         from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -277,8 +268,8 @@ class TestTaskScorer:
 
     def test_score_clickworker_terminal(self, scorer):
         """Test scoring Clickworker task in Terminal state (debt $9.50-10)."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
         from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -299,8 +290,7 @@ class TestTaskScorer:
 
     def test_score_low_pay_rejected(self, scorer):
         """Test that low pay tasks are rejected."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
-        from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -319,8 +309,7 @@ class TestTaskScorer:
 
     def test_score_paypal_payment_penalty(self, scorer):
         """Test that PayPal payment method gets lower reliability."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
-        from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.PROLIFIC,
@@ -340,8 +329,7 @@ class TestTaskScorer:
 
     def test_score_crypto_payment_penalty(self, scorer):
         """Test that crypto payment method gets lowest reliability."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
-        from src.state_machine import State
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.DATA_ANNOTATION,
@@ -359,7 +347,7 @@ class TestTaskScorer:
 
     def test_score_batch_sorted(self, scorer):
         """Test batch scoring returns sorted results."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidates = [
             TaskCandidate(
@@ -390,7 +378,7 @@ class TestTaskScorer:
 
     def test_filter_executable(self, scorer):
         """Test filtering only executable tasks."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidates = [
             TaskCandidate(
@@ -420,7 +408,7 @@ class TestTaskScorer:
 
     def test_unknown_platform_defaults(self, scorer):
         """Test scoring with unknown platform uses defaults."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         # Create a candidate with a platform not in PLATFORM_DATA
         candidate = TaskCandidate(
@@ -447,7 +435,7 @@ class TestTaskResult:
     """Test TaskResult model."""
 
     def test_task_result_creation(self):
-        from src.task_scorer import TaskResult, TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskResult, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -555,7 +543,7 @@ class TestClickworkerConnector:
     async def test_execute_task_success(self, mock_context):
         """Test successful task execution."""
         from src.task_executor import ClickworkerConnector
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         context, page = mock_context
 
@@ -581,7 +569,7 @@ class TestClickworkerConnector:
     async def test_execute_task_failure(self, mock_context):
         """Test task execution failure."""
         from src.task_executor import ClickworkerConnector
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         context, page = mock_context
         page.goto = AsyncMock(side_effect=Exception("Network error"))
@@ -789,8 +777,8 @@ class TestTaskExecutor:
     @pytest.mark.asyncio
     async def test_get_connector_creates_and_logs_in(self, executor):
         """Test getting connector creates it and logs in."""
-        from src.task_scorer import Platform
         from src.task_executor import ClickworkerConnector
+        from src.task_scorer import Platform
 
         mock_connector = AsyncMock(spec=ClickworkerConnector)
         mock_connector.login = AsyncMock(return_value=True)
@@ -808,8 +796,8 @@ class TestTaskExecutor:
     @pytest.mark.asyncio
     async def test_get_connector_no_credentials(self, executor):
         """Test getting connector without credentials raises error."""
-        from src.task_scorer import Platform
         from src.task_executor import ExecutionError
+        from src.task_scorer import Platform
 
         with pytest.raises(ExecutionError, match="No credentials"):
             await executor._get_connector(Platform.CLICKWORKER)
@@ -817,7 +805,7 @@ class TestTaskExecutor:
     @pytest.mark.asyncio
     async def test_discover_tasks(self, executor):
         """Test discovering tasks from multiple platforms."""
-        from src.task_scorer import Platform, TaskCandidate, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         mock_connector1 = AsyncMock()
         mock_connector1.find_tasks = AsyncMock(return_value=[
@@ -853,8 +841,8 @@ class TestTaskExecutor:
     @pytest.mark.asyncio
     async def test_execute_task_credits_wallet(self, executor, mock_wallet):
         """Test that successful task execution credits wallet."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod, TaskResult
         from src.task_executor import ClickworkerConnector
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskResult, TaskType
 
         await executor.start()
 
@@ -897,8 +885,8 @@ class TestTaskExecutor:
     @pytest.mark.asyncio
     async def test_execute_task_failure_no_wallet_credit(self, executor, mock_wallet):
         """Test that failed task doesn't credit wallet."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod, TaskResult
         from src.task_executor import ClickworkerConnector
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskResult, TaskType
 
         mock_connector = AsyncMock(spec=ClickworkerConnector)
         mock_connector.execute_task = AsyncMock(return_value=TaskResult(
@@ -938,7 +926,7 @@ class TestTaskExecutor:
     @pytest.mark.asyncio
     async def test_execute_batch(self, executor, mock_wallet):
         """Test executing batch of tasks."""
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod, TaskResult
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskResult, TaskType
 
         mock_connector = AsyncMock()
         mock_connector.execute_task = AsyncMock(side_effect=[
@@ -1009,7 +997,7 @@ class TestMockExecuteTask:
     async def test_mock_execute_task(self):
         """Test mock execution returns valid result."""
         from src.task_executor import mock_execute_task
-        from src.task_scorer import TaskCandidate, Platform, TaskType, PaymentMethod
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskType
 
         candidate = TaskCandidate(
             platform=Platform.CLICKWORKER,
@@ -1049,10 +1037,11 @@ class TestTaskScorerExecutorIntegration:
     @pytest.mark.asyncio
     async def test_full_cycle_mock(self):
         """Test full discover -> score -> execute cycle with mocks."""
-        from src.task_scorer import TaskScorer, TaskCandidate, Platform, TaskType, PaymentMethod
-        from src.task_executor import mock_execute_task, TaskExecutor
-        from src.wallet import Wallet
         from decimal import Decimal
+
+        from src.task_executor import mock_execute_task
+        from src.task_scorer import PaymentMethod, Platform, TaskCandidate, TaskScorer, TaskType
+        from src.wallet import Wallet
 
         wallet = Wallet()
         scorer = TaskScorer()

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,9 +1,10 @@
 """Unit tests for wallet.py — dual-pool wallet."""
 
-import pytest
 from decimal import Decimal
 
-from src.wallet import Wallet, WalletError, SpendRequest
+import pytest
+
+from src.wallet import SpendRequest, Wallet, WalletError
 
 
 class TestCreditEarned:


### PR DESCRIPTION
## What
Add `.ruff.toml` (matching the real CI gate from PR #36) and sweep all 109 pre-existing ruff errors across `src/` and `tests/` so `ruff check src tests` is green on main. Pure lint/formatting plus removal of provably dead code — no behavior change (full pytest suite still green).

## Spec reference
artifact.md §16 (Deployment Pipeline): GitHub Actions runs `ruff lint + pytest`; nothing broken merges.

## Task
Closes #47

## Testing
- `ruff check src tests` → **All checks passed!**
- `python -m pytest -q` → 218-220 passed; only the 2 known pre-existing flaky tests (`test_websocket_receives_debt_tick`, `test_full_cycle_mock`) fail intermittently, confirmed identical on clean main.