### PR TITLE
fix(persistence): preserve soul-crystal archive across reincarnation wipe

### DIFF
--- a/main.py
+++ b/main.py
@@ -286,8 +286,9 @@ class SurvivalLoop:
     def _reincarnate(self, state: DebtState) -> None:
         """Reset hot-memory state for a new life.
 
-        Soul crystals (permanent memory, §10 Layer 2/3) survive the wipe;
-        only hot-memory state (wallet, task queue, events, life record) is reset.
+        Soul crystals (permanent memory, §10 Layer 2/3) survive the wipe —
+        ``clear()`` preserves the archive by contract; only hot-memory state
+        (wallet, task queue, events, life record) is reset here.
         """
         logger.info("Reincarnating — resetting hot-memory state")
         self._event_log.append("REINCARNATION")
@@ -306,10 +307,9 @@ class SurvivalLoop:
         self.cold_archive.reset_for_new_life()
         self.cold_archive.begin_life(new_life_num)
 
-        # Wipe hot-memory state, preserving the permanent soul-crystal archive
+        # Wipe hot-memory state; the permanent soul-crystal archive is
+        # preserved by clear() (and lives on in the engine's memory).
         self.persistence.clear()
-        for crystal in self.reincarnation.soul_crystals:
-            self.persistence.save_soul_crystal(crystal)
 
         # Load ancestral memory — compress all past soul crystals
         # into a bounded block (never blocks a new life from starting)

--- a/src/persistence.py
+++ b/src/persistence.py
@@ -160,7 +160,8 @@ class PersistenceStore(ABC):
     def load_events(self) -> list[str]: ...
 
     @abstractmethod
-    def clear(self) -> None: ...
+    def clear(self) -> None:
+        """Reset hot-memory state while preserving the soul-crystal archive."""
 
 
 # ---------------------------------------------------------------------------
@@ -212,10 +213,12 @@ class InMemoryStore(PersistenceStore):
         return list(self._events)
 
     def clear(self) -> None:
+        # Preserve the permanent soul-crystal archive (§10 Layer 2/3): it must
+        # survive reincarnation. Only wipe the hot-memory state (wallet, task
+        # queue, events, life record) that belongs to the dying life.
         self._debt_state = None
         self._wallet = None
         self._life_record = None
-        self._soul_crystals.clear()
         self._events.clear()
 
 
@@ -359,9 +362,16 @@ class SupabaseStore(PersistenceStore):
     # -- lifecycle ----------------------------------------------------------
 
     def clear(self) -> None:
-        """Wipe all hot-memory tables (called on death / reincarnation)."""
-        for table in self._ROW_TABLES + self._LIST_TABLES:
+        """Reset hot-memory state (called on death / reincarnation).
+
+        Preserves the permanent soul-crystal archive — soul crystals are
+        §10 Layer 2/3 permanent memory and must survive the wipe. Only the
+        dying life's hot-memory tables (debt_state, wallet, life_record,
+        events) are reset.
+        """
+        for table in self._ROW_TABLES:
             self._delete_all(table)
+        self._delete_all("events")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -218,6 +218,59 @@ class TestFullLifeDeathReincarnation:
         assert "Life 2" in mem
         assert "2 lives" in mem
 
+    def test_persistence_keeps_crystal_and_prunes_events_after_reincarnation(self):
+        """After death → reincarnation, hot-memory state resets while the
+        permanent soul-crystal archive and the per-life event log are both
+        correct in persistence (no cross-life bleed, no lost crystals).
+        """
+        from main import SurvivalLoop
+
+        store = InMemoryStore()
+        loop = SurvivalLoop(persistence=store)
+        loop.research.research_earning_platforms = AsyncMock(return_value=[])
+
+        # Accumulate a full life of debt ticks → death → reincarnation.
+        _tick_to_death(loop)
+
+        # The new life's hot-memory state is reset...
+        assert loop.debt_engine.debt == Decimal("0.00")
+        assert loop.debt_engine.state.life_number == 2
+        assert loop._event_log == ["Life 2 born"]
+
+        # ...and persisted as such: debt_state/wallet/life_record reflect life 2.
+        saved_debt = store.load_debt_state()
+        assert saved_debt is not None
+        assert saved_debt.debt == Decimal("0.00")
+        assert saved_debt.life_number == 2
+
+        saved_life = store.load_life_record()
+        assert saved_life is not None
+        assert saved_life.life_number == 2
+
+        # Event table is pruned to the current life only — no bleed of the
+        # 20+ debt-tick / death events from life 1.
+        assert store.load_events() == ["Life 2 born"]
+
+        # The permanent soul-crystal archive survives the wipe and is intact.
+        crystals = store.load_soul_crystals()
+        assert [c.life for c in crystals] == [1]
+
+    def test_second_reincarnation_does_not_duplicate_crystals(self):
+        """Dying twice must archive exactly one crystal per life — the
+        preserved archive must never be duplicated by reincarnation."""
+        from main import SurvivalLoop
+
+        store = InMemoryStore()
+        loop = SurvivalLoop(persistence=store)
+        loop.research.research_earning_platforms = AsyncMock(return_value=[])
+
+        _tick_to_death(loop)  # life 1 → death → life 2
+        _tick_to_death(loop)  # life 2 → death → life 3
+
+        assert [c.life for c in store.load_soul_crystals()] == [1, 2]
+        assert loop.debt_engine.state.life_number == 3
+        assert store.load_events() == ["Life 3 born"]
+
 
 # ---------------------------------------------------------------------------
 # Health endpoint

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -222,8 +222,12 @@ class TestInMemoryStore:
         assert store.load_debt_state() is None
         assert store.load_wallet() is None
         assert store.load_life_record() is None
-        assert store.load_soul_crystals() == []
         assert store.load_events() == []
+
+        # Soul crystals are permanent (§10 Layer 2/3) and must survive a wipe.
+        crystals = store.load_soul_crystals()
+        assert len(crystals) == 1
+        assert crystals[0].life == 1
 
     def test_save_overwrites_previous(self, store):
         store.save_debt_state(DebtState(debt=Decimal("1.00")))


### PR DESCRIPTION
Closes the leading self-contained item from consensus (Cycle 15): make SupabaseStore.clear() + _reincarnate robust across stores, confirming the soul-crystal happy path and event-table pruning.

## Problem

The permanent soul-crystal archive (section 10 Layer 2/3) survived reincarnation only because SurvivalLoop._reincarnate re-saved every crystal by hand *after* calling clear(). Both SupabaseStore.clear() and InMemoryStore.clear() wiped the soul_crystals table/collection outright. This put irreversible, permanent memory at the mercy of a single orchestration sequence — any other call to clear() (or a future refactor that reordered _reincarnate) would silently destroy the archive.

## Fix

Move the invariant into the store contract:

- clear() now preserves the soul-crystal archive. InMemoryStore.clear() and SupabaseStore.clear() reset only hot-memory tables (debt_state, wallet, life_record, events) and leave soul_crystals intact.
- _reincarnate drops the redundant re-save loop. Now that clear() preserves the archive, the old re-save loop would have *duplicated* crystals on every reincarnation (since save_soul_crystal appends). Removing it makes the happy path correct across both stores.

## Tests

- tests/test_persistence.py::test_clear — updated to assert soul crystals survive a wipe (was asserting they were destroyed).
- tests/test_main_loop.py::TestFullLifeDeathReincarnation — two new deterministic tests:
  - test_persistence_keeps_crystal_and_prunes_events_after_reincarnation: after a full life → death → rebirth, hot state resets, the event table is pruned to ["Life 2 born"] (no cross-life bleed), and the life-1 crystal is preserved intact.
  - test_second_reincarnation_does_not_duplicate_crystals: dying twice archives exactly [1, 2] crystals (no duplication).

## Verification

- New tests 5x consecutive passes (deterministic, not flaky).
- Full suite: 221 passed (baseline was 219 + 2 new); only failure is the pre-existing flaky test_websocket_receives_debt_tick, which is separately fixed in #50.
- Edited lines ruff-clean; no new lint debt introduced (pre-existing UP045/DTZ001/I001 debt is the deferred #48 sweep, left untouched to avoid conflict).

Does not conflict with #46 (event replace) or #44 (respawn).
