### PR TITLE
fix(survival): never resume a torn partial-write snapshot

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,6 +133,32 @@ class SurvivalLoop:
     def _restore_state(self) -> None:
         """Restore hot-memory state from persistence on startup."""
         debt_state = self.persistence.load_debt_state()
+        wallet_data = self.persistence.load_wallet()
+        life_record = self.persistence.load_life_record()
+
+        # The core hot-memory entities (debt_state, wallet, life_record) are
+        # written together as a coherent unit by _persist_all. If only *some*
+        # of them survived (e.g. a write failed partway, or the process died
+        # between saves), resuming would resurrect the agent in a torn state —
+        # alive with no wallet. Treat a partial set as corrupt and start fresh
+        # rather than restoring an inconsistent half-snapshot.
+        present = {
+            "debt_state": debt_state is not None,
+            "wallet": wallet_data is not None,
+            "life_record": life_record is not None,
+        }
+        if any(present.values()) and not all(present.values()):
+            logger.warning(
+                "Inconsistent persisted snapshot (%s) — treating as partial "
+                "write and starting a fresh life",
+                present,
+            )
+            # Load the permanent archive first so the fresh life inherits the
+            # correct next life number and ancestral memory.
+            self.reincarnation.soul_crystals = self.persistence.load_soul_crystals()
+            self._start_fresh_life()
+            return
+
         if debt_state:
             self.debt_engine.restore(debt_state)
             logger.info(
@@ -142,7 +168,6 @@ class SurvivalLoop:
                 debt_state.alive,
             )
 
-        wallet_data = self.persistence.load_wallet()
         if wallet_data:
             self.wallet = Wallet(
                 locked=Decimal(wallet_data["locked"]),
@@ -151,7 +176,6 @@ class SurvivalLoop:
             )
             logger.info("Restored wallet: $%s total", self.wallet.total_balance)
 
-        life_record = self.persistence.load_life_record()
         if life_record:
             self._life_record = life_record
             logger.info("Restored life record: life %d", life_record.life_number)
@@ -164,11 +188,19 @@ class SurvivalLoop:
 
         # If no life record exists yet, start life 1
         if self._life_record is None:
-            life_num = self.reincarnation.next_life_number()
-            self._life_record = self.reincarnation.start_new_life(life_num)
-            self._persist_all()
-            self.cold_archive.begin_life(life_num)
-            logger.info("Started new life: %d", life_num)
+            self._start_fresh_life()
+
+    def _start_fresh_life(self) -> None:
+        """Begin life 1 (or the next life) with clean hot-memory state."""
+        life_num = self.reincarnation.next_life_number()
+        self.debt_engine.reset_for_new_life(life_num)
+        self.state_machine.reset()
+        self.wallet = Wallet()
+        self._life_record = self.reincarnation.start_new_life(life_num)
+        self._event_log = [f"Life {life_num} born"]
+        self._persist_all()
+        self.cold_archive.begin_life(life_num)
+        logger.info("Started new life: %d", life_num)
 
     def _persist_all(self) -> None:
         """Persist all hot-memory state."""

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -375,6 +375,96 @@ class TestPersistenceFallback:
         assert loop2.debt_engine.debt == Decimal("1.50")
         assert loop2.wallet.debt == Decimal("1.50")
 
+    def test_partial_snapshot_missing_wallet_starts_fresh(self):
+        """A torn snapshot (debt+life present, wallet missing) must not resume.
+
+        Resuming the half-written snapshot would resurrect the agent alive with
+        no wallet. The loop must instead fall back to a fresh life.
+        """
+        from datetime import datetime, timezone
+
+        from main import SurvivalLoop
+        from src.debt_engine import DebtState, DifficultyMode
+        from src.soul_crystal import LifeRecord
+
+        store = InMemoryStore()
+        store.save_debt_state(
+            DebtState(
+                debt=Decimal("6.00"),
+                mode=DifficultyMode.NORMAL,
+                alive=True,
+                life_number=2,
+            )
+        )
+        store.save_life_record(
+            LifeRecord(life_number=2, born_at=datetime.now(timezone.utc))
+        )
+        # wallet deliberately absent — simulates a partial write
+
+        loop = SurvivalLoop(persistence=store)
+
+        # Must NOT have resumed the torn $6.00 alive snapshot.
+        assert loop.debt_engine.debt == Decimal("0.00")
+        assert loop.wallet.total_balance == Decimal("0.00")
+        assert loop._life_record is not None
+
+    def test_partial_snapshot_missing_debt_state_starts_fresh(self):
+        """A torn snapshot (wallet+life present, debt_state missing) must not resume."""
+        from datetime import datetime, timezone
+
+        from main import SurvivalLoop
+        from src.soul_crystal import LifeRecord
+
+        store = InMemoryStore()
+        store.save_wallet(Wallet(locked=Decimal("9.00"), free=Decimal("9.00")))
+        store.save_life_record(
+            LifeRecord(life_number=5, born_at=datetime.now(timezone.utc))
+        )
+        # debt_state deliberately absent
+
+        loop = SurvivalLoop(persistence=store)
+
+        assert loop.wallet.total_balance == Decimal("0.00")
+        assert loop.debt_engine.debt == Decimal("0.00")
+        assert loop._life_record.life_number == 1
+
+    def test_partial_snapshot_inherits_next_life_from_archive(self):
+        """A torn snapshot still starts at the next life per the permanent archive."""
+        from datetime import datetime, timezone
+
+        from main import SurvivalLoop
+        from src.debt_engine import DebtState, DifficultyMode
+        from src.soul_crystal import LifeRecord, SoulCrystal
+
+        store = InMemoryStore()
+        store.save_debt_state(
+            DebtState(
+                debt=Decimal("3.00"),
+                mode=DifficultyMode.NORMAL,
+                alive=True,
+                life_number=2,
+            )
+        )
+        store.save_life_record(
+            LifeRecord(life_number=2, born_at=datetime.now(timezone.utc))
+        )
+        # Permanent archive survives — life 1 already crystalised
+        store.save_soul_crystal(
+            SoulCrystal(
+                life=1,
+                born=datetime(2026, 9, 1, tzinfo=timezone.utc),
+                died=datetime(2026, 9, 21, tzinfo=timezone.utc),
+                lifespan_days=20.0,
+            )
+        )
+        # wallet deliberately absent
+
+        loop = SurvivalLoop(persistence=store)
+
+        # Fresh life number derives from the archive: max(1) + 1 = 2
+        assert loop.debt_engine.snapshot().life_number == 2
+        assert loop.wallet.total_balance == Decimal("0.00")
+
 # ---------------------------------------------------------------------------
 # Status endpoint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #52.

`SurvivalLoop._persist_all` writes the hot-memory entities (debt_state, wallet, life_record, events) sequentially as a coherent unit. If a write fails partway — a transient Supabase error, or the process crashing between saves — the store holds an `inconsistent` snapshot. Restoring each entity independently could resurrect the agent **alive with no wallet**, an unrecoverable torn state.

## Change

`_restore_state` now:
1. Loads debt_state, wallet, and life_record **up front**.
2. If *some but not all* are present, treats the snapshot as a partial write: logs a warning and falls back to a **fresh life** instead of resuming the torn half-state.
3. Loads the permanent soul-crystal archive first so the fresh life inherits the correct next life number and ancestral memory.

A shared `_start_fresh_life` helper (the reincarnation reset path) now backs both the partial-write fallback and the existing no-life-record startup branch — no duplicated reset logic.

## Tests

- `test_partial_snapshot_missing_wallet_starts_fresh` — debt+life present, wallet missing → does NOT resume alive at $6, starts fresh.
- `test_partial_snapshot_missing_debt_state_starts_fresh` — wallet+life present, debt missing → starts fresh.
- `test_partial_snapshot_inherits_next_life_from_archive` — fresh life number derives from the permanent archive (max+1).

Full suite: **222 passed** (baseline 219 + 3 new); only remaining failure is the pre-existing flaky `test_websocket_receives_debt_tick` (already fixed in unmerged #50). No new ruff debt (line counts match base main; main's remaining rules are the #48 sweep's job).